### PR TITLE
Modify FACT run flags

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ start () {
     # usecase to change the database path inside the docker container
     if [ -e /media/data/fact_wt_mongodb/REINITIALIZE_DB ]; then
         python3 /opt/FACT_core/src/init_database.py && \
-            rm /media/data/fact_wt_mongodb/REINITIALIZE_DB
+            rm -rf /media/data/fact_wt_mongodb/REINITIALIZE_DB
     fi
 
     # TODO This only works when the radare server runs on the docker host

--- a/start.py
+++ b/start.py
@@ -88,7 +88,7 @@ def run(args):
     cmd = f"""docker run \
     {pass_docker_socket_args(args)} \
     {mount_relevant_dirs_for_docker_args(args.docker_mount_base_dir)} \
-    -it \
+    --detach \
     --name {args.name} \
     --hostname {args.name} \
     --group-add {mongodb_path_gid} \


### PR DESCRIPTION
This PR includes the following changes:

Remove interative mode for container (aka -it option)
Add new flags for run command in start.py: --detach option and replace --config-path for --config-file.